### PR TITLE
Remove gcov usage until it can be used.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cake_minimum_required(VERSION 3.11)
 
 project(everest-log
     VERSION 0.2.1
@@ -75,17 +75,18 @@ if(BUILD_TESTING)
 
     append_coverage_compiler_flags()
 
-    setup_target_for_coverage_gcovr_html(
-        NAME gcovr_coverage_liblog
-        EXECUTABLE test_config
-        DEPENDENCIES test_config everest
-    )
+    #TODO: Restore once tests actually run.
+    #setup_target_for_coverage_gcovr_html(
+        #NAME gcovr_coverage_liblog
+        #EXECUTABLE test_config
+        #DEPENDENCIES test_config everest
+    #)
 
-    setup_target_for_coverage_lcov(
-        NAME lcov_coverage_liblog
-        EXECUTABLE test_config
-        DEPENDENCIES test_config everest
-    )
+    #setup_target_for_coverage_lcov(
+        #NAME lcov_coverage_liblog
+        #EXECUTABLE test_config
+        #DEPENDENCIES test_config everest
+    #)
 else()
     message("Not running unit tests")
 endif()


### PR DESCRIPTION
Until tests can be run successfully (everest-framework depends on liblog), removing dependencies can help simplify our efforts at automating builds and tests.
